### PR TITLE
채팅방 스크롤/프로필 완성도 높이기

### DIFF
--- a/src/components/chat/Chat.jsx
+++ b/src/components/chat/Chat.jsx
@@ -48,16 +48,6 @@ const Chat = () => {
     firstMessageRef.current = datas[0].id;
     AddMessages(datas, messageRef.current, chatMembersRef.current, "prepend");
   };
-  const callPrevMessages = new IntersectionObserver((entries, observer) => {
-    entries.forEach((entry) => {
-      console.log("entry", entry);
-      if (!entry.isIntersecting) return;
-      //entry가 intersecting중이 아니라면 구현하지 않는다.
-
-      console.log("observer", observer);
-      callMessageBefore();
-    });
-  });
 
   const toggleOpen = (e) => {
     e.stopPropagation();
@@ -144,6 +134,15 @@ const Chat = () => {
         lastMessageRef.current = datas2[datas2.length - 1].id;
 
         //데이터 그리기가 끝난 후 옵저버를 켭니다.
+        const options = {
+          root: document.querySelector(".text-area"),
+          rootMargin: "100px",
+          threshold: [0, 1],
+        };
+        const callPrevMessages = new IntersectionObserver(
+          callMessageBefore,
+          options
+        );
         callPrevMessages.observe(observerRef.current);
       } catch (error) {
         console.error(error, "에러");


### PR DESCRIPTION
채팅방 스크롤이 좀 더 완성도 있게 움직이게 되었습니다.
1. useState로 사용하던 chatMembers를 useRef.current로 변경, 프로필 이미지를 표기할 수 있게 되었습니다.
2. intersectionObserver에 options를 추가하여 옵저버가 채팅방에 노출되지 않고, 자연스럽게 이전 메세지가 로딩될 수 있도록 하였습니다.
3. 채팅방 초기 진입 시 메세지 길이별로 스크롤 위치를 조정합니다. 이전에 읽은 메세지 기준으로 스크롤이 자연스럽게 위치하게 됩니다. 기존에 존재하던 "입장하였습니다." 메세지는 추후 "마지막으로 읽은 메세지"로 바꾸면 될 것 같습니다.

멘토님께 chatMembers를 컴포넌트 props로 넘기는 편이 더 바람직하다는 조언을 들었지만, 메세지 영역을 컴포넌트로 분리하려다 많은 시간을 들이고 실패해 useRef.current로 타협했습니다. 리팩토링 도전과제로 삼으려 합니다.