### PR TITLE
머지 이후 채팅방 정상화

### DIFF
--- a/src/assets/constants/instance.jsx
+++ b/src/assets/constants/instance.jsx
@@ -36,14 +36,13 @@ instance.interceptors.response.use(
     const { response } = error;
     if (response.data.status === 401) {
       if (
-        response.data.errorCode === "MISMATCH_REFRESH_TOKEN" ||
+        response.data.errorCode === "REFRESH_TOKEN_EXPIRED" ||
         response.data.errorCode === "NOT_EXIST_REFRESH_TOKEN"
       ) {
+        console.log(response.data.message);
         localStorage.removeItem("withcon_token");
         localStorage.removeItem("favorites");
         sessionStorage.clear();
-        window.alert("세션이 만료되었습니다. 로그인해주세요.");
-        useNavigate("/login/");
         return;
       }
     }

--- a/src/assets/tools/chatFunctions.jsx
+++ b/src/assets/tools/chatFunctions.jsx
@@ -74,11 +74,8 @@ const ChatMessageBundle = class {
     this.setPrevMessage = setPrevMessage;
   }
 
+  //이전 메세지 호출 함수. id 숫자 계산해서 요청.
   callMessageBefore = async () => {
-    if (this.firstMessageRef.current <= 1) {
-      this.setIsPrev(false);
-      return;
-    }
     let url = "/chatMessages";
     url += `?_start=${Math.max(
       0,
@@ -86,7 +83,7 @@ const ChatMessageBundle = class {
     )}&_limit=10`;
     const response = await instance.get(url);
     const datas = await response.data;
-    if (datas.length < 10) this.setIsPrev(false); //적절한 쿼리스트링 필요.
+    //if (datas.length < 10) this.setIsPrev(false); //적절한 쿼리스트링 필요.
     this.firstMessageRef.current = datas[0].id;
     AddMessages(
       datas,
@@ -111,10 +108,24 @@ const ChatMessageBundle = class {
       this.firstMessageRef.current = datas2[0]?.id || 0;
       this.lastMessageRef.current = datas2[datas2.length - 1]?.id;
       this.setPrevMessage(datas2[datas2.length - 1]);
+
+      AddMessages(
+        datas2,
+        this.messageRef.current,
+        this.chatMembersRef.current,
+        "append",
+        this.myId
+      );
+      if (datas2.length < 10) {
+        await this.callMessageBefore();
+        this.messageRef.current.scrollIntoView(false);
+      } else {
+        this.messageRef.current.scrollIntoView(true);
+      }
     } catch (error) {
       console.error(error, "에러");
     }
   };
 };
 
-export { ChatMessageBundle, ChatConcentration as default };
+export { ChatMessageBundle, ChatConcentration };

--- a/src/assets/tools/chatFunctions.jsx
+++ b/src/assets/tools/chatFunctions.jsx
@@ -1,0 +1,120 @@
+import axios from "axios";
+import AddMessages from "../../components/chat/AddMessages";
+const instance = axios.create({ baseURL: "http://localhost:3000" });
+
+const ChatConcentration = class {
+  constructor(chatRoomId, myId, lastMessageRef) {
+    this.chatRoomId = chatRoomId;
+    this.myId = myId;
+    this.lastMessageRef = lastMessageRef;
+  }
+
+  sendVisible(visibleType) {
+    const obj = {
+      chatRoomId: this.chatRoomId,
+      visibleType: visibleType,
+    };
+    return obj;
+  }
+
+  enterRoomNow = () => {
+    const data = {
+      chatRoomId: this.chatRoomId,
+      targetId: this.myId,
+      messageType: "ENTER",
+    };
+    instance.post("/notification/chatRoom-event", data);
+    instance.post("/notification/visible", this.sendVisible("VISIBLE"));
+  };
+
+  changeVisibility = () => {
+    const visibility = document.hidden ? "HIDDEN" : "VISIBLE";
+    /**instance.post("/notification", sendVisible(visibility));
+      navigator.sendBeacon(
+        "http://localhost:3000/notification",
+        sendVisible(visibility)
+      );*/
+    instance.post("/notification/visible", this.sendVisible(visibility));
+    if (document.hidden) {
+      const id = this.lastMessageRef.current;
+      localStorage.setItem("chat", JSON.stringify(id));
+    }
+  };
+
+  beforeUnload = () => {
+    instance.post("/notification/visible", this.sendVisible("HIDDEN"));
+    const id = this.lastMessageRef.current;
+    localStorage.setItem("chat", JSON.stringify(id));
+  };
+
+  hashChange = () => {
+    instance.post("/notification/visible", this.sendVisible("HIDDEN"));
+    const id = this.lastMessageRef.current;
+    localStorage.setItem("chat", JSON.stringify(id));
+    window.removeEventListener("popstate", this.hashChange);
+  };
+};
+
+const ChatMessageBundle = class {
+  constructor(
+    firstMessageRef,
+    lastMessageRef,
+    messageRef,
+    chatMembersRef,
+    myId,
+    setIsPrev,
+    setPrevMessage
+  ) {
+    this.firstMessageRef = firstMessageRef;
+    this.lastMessageRef = lastMessageRef;
+    this.messageRef = messageRef;
+    this.chatMembersRef = chatMembersRef;
+    this.myId = myId;
+    this.setIsPrev = setIsPrev;
+    this.setPrevMessage = setPrevMessage;
+  }
+
+  callMessageBefore = async () => {
+    if (this.firstMessageRef.current <= 1) {
+      this.setIsPrev(false);
+      return;
+    }
+    let url = "/chatMessages";
+    url += `?_start=${Math.max(
+      0,
+      this.firstMessageRef.current - 11
+    )}&_limit=10`;
+    const response = await instance.get(url);
+    const datas = await response.data;
+    if (datas.length < 10) this.setIsPrev(false); //적절한 쿼리스트링 필요.
+    this.firstMessageRef.current = datas[0].id;
+    AddMessages(
+      datas,
+      this.messageRef.current,
+      this.chatMembersRef.current,
+      "prepend",
+      this.myId
+    );
+  };
+
+  callInitialMessages = async () => {
+    try {
+      let startId = localStorage.getItem("chat");
+      let url = "/chatMessages";
+      url += startId
+        ? `?_start=${startId - 1}&_limit=10`
+        : "?_start=1&_limit=30";
+      const response2 = await instance.get(url);
+      const datas2 = await response2.data;
+
+      //로컬스토리지용 아이디 세팅
+      this.firstMessageRef.current = datas2[0]?.id || 0;
+      this.lastMessageRef.current = datas2[datas2.length - 1]?.id;
+      this.setPrevMessage(datas2[datas2.length - 1]);
+    } catch (error) {
+      console.error(error, "에러");
+    }
+  };
+};
+
+export { ChatMessageBundle, ChatConcentration as default };

--- a/src/assets/tools/setLists.jsx
+++ b/src/assets/tools/setLists.jsx
@@ -3,7 +3,6 @@ import instance from "../constants/instance";
 const setLists = async (request, setInfos, totalCount, setTotalCount) => {
   const response = await instance.get(request);
   const datas = await response.data;
-  console.log(datas);
   setInfos(datas.content);
   const length = datas.totalElements;
   if (length !== totalCount) {

--- a/src/assets/tools/setLists.jsx
+++ b/src/assets/tools/setLists.jsx
@@ -3,6 +3,7 @@ import instance from "../constants/instance";
 const setLists = async (request, setInfos, totalCount, setTotalCount) => {
   const response = await instance.get(request);
   const datas = await response.data;
+  console.log(datas);
   setInfos(datas.content);
   const length = datas.totalElements;
   if (length !== totalCount) {

--- a/src/components/chat/AddMessages.jsx
+++ b/src/components/chat/AddMessages.jsx
@@ -6,26 +6,26 @@ const AddMessages = (datas, parentNode, chatMembers, direction, me) => {
     let same = false;
     if (i) {
       if (
-        datas[i - 1].from === datas[i].from &&
-        datas[i].timeStamp - datas[i - 1].timeStamp < 10000
+        datas[i - 1].memberId === datas[i].memberId &&
+        datas[i].sendAt - datas[i - 1].sendAt < 10000
       ) {
         same = true;
       }
     }
 
-    let profileImage = "";
+    let memberdata = "";
     if (datas[i].memberId === me) {
-      datas[i].memberId = "me";
+      datas[i].memberId = 0;
     } else {
       for (const member of chatMembers) {
         if (member.username === datas[i].memberId) {
-          profileImage = member.profileImage;
+          memberdata = member;
           break;
         }
       }
     }
 
-    ChatMessageForm(datas[i], $fragment, same, profileImage);
+    ChatMessageForm(datas[i], $fragment, same, memberdata);
   }
 
   if (direction === "prepend") {

--- a/src/components/chat/Chat.jsx
+++ b/src/components/chat/Chat.jsx
@@ -98,6 +98,11 @@ const Chat = () => {
     }
     const changeVisibility = () => {
       const visibility = document.hidden ? "HIDDEN" : "VISIBLE";
+      /**instance.post("/notification", sendVisible(visibility));
+      navigator.sendBeacon(
+        "http://localhost:3000/notification",
+        sendVisible(visibility)
+      );*/
       instance.post("/notification/visible", sendVisible(visibility));
       if (document.hidden) {
         const id = lastMessageRef.current;

--- a/src/components/chat/ChatList.jsx
+++ b/src/components/chat/ChatList.jsx
@@ -5,6 +5,7 @@ import CreateChatRoom from "./CreateChatRoom";
 import Paging from "../common/Paging";
 import instance from "../../assets/constants/instance";
 import setLists from "../../assets/tools/setLists";
+import PAGE from "../../assets/constants/page";
 
 const ChatList = () => {
   const [tagInfo, setTagInfo] = useState([]);
@@ -48,7 +49,7 @@ const ChatList = () => {
       try {
         let url = "/chatRoom/performance/";
         url += concertTitle;
-        url += `?_page=${pages}&_limit=10`;
+        url += `?page=${pages - 1}&limit=${PAGE.limit}`;
         await setLists(url, setData, totalCount, setTotalCount);
       } catch (error) {
         console.error("데이터오류", error);

--- a/src/components/chat/ChatMessageForm.jsx
+++ b/src/components/chat/ChatMessageForm.jsx
@@ -8,9 +8,9 @@ const ChatMessageForm = (message, parentNode, same, memberdata) => {
   const $time = document.createElement("p");
 
   $node.className =
-    message.memberId === "me"
+    message.memberId === 0
       ? "member-me"
-      : message.from === "system"
+      : message.memberId === "system"
       ? "system-message"
       : "member-other";
   $img.src = memberdata.profileImage;
@@ -19,8 +19,8 @@ const ChatMessageForm = (message, parentNode, same, memberdata) => {
   $chatTexts.className = "chat-texts";
   $chatMessageInfo.className = "chat-message-info";
   $username.className = "username";
-  $username.innerText = memberdata.nickname;
-  if (message.memberId === "me" || same) {
+  $username.innerText = memberdata.nickName;
+  if (message.memberId === 0 || same) {
     $img.classList.add("invisible");
     $username.classList.add("hidden");
   }

--- a/src/components/chat/MyChat.jsx
+++ b/src/components/chat/MyChat.jsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import ChatRoom from "./ChatRoom";
 import Paging from "../common/Paging";
 import setLists from "../../assets/tools/setLists";
+import PAGE from "../../assets/constants/page";
 
 const MyChat = () => {
   const [datas, setData] = useState([]);
@@ -16,7 +17,7 @@ const MyChat = () => {
     const getData = async () => {
       try {
         let url = "/chatRoom/member";
-        url += `?_page=${pages}&_limit=10`;
+        url += `?page=${pages - 1}&limit=${PAGE.limit}`;
         await setLists(url, setData, totalCount, setTotalCount);
       } catch (error) {
         console.error("데이터오류", error);

--- a/src/components/concert/ConLists.jsx
+++ b/src/components/concert/ConLists.jsx
@@ -35,32 +35,7 @@ const ConLists = () => {
     };
     getInfos();
     setCurrentPage(pages);
-
-    //바뀐 정보로 카드를 그려요
-    infos.map((info, index) => {
-      let like = false;
-      if (favorites && favorites.includes(info.id + "")) {
-        like = true;
-      }
-      concertCards.push(
-        <ConcertCard
-          info={info}
-          key={index}
-          like={like}
-          setLike={setFavorites}
-        />
-      );
-    });
-    if (!infos.length) {
-      concertCards.push(
-        <div key="1">
-          <h2 className="notice">결과가 없습니다</h2>
-        </div>
-      );
-    }
   }, [url]);
-
-  const concertCards = [];
 
   return (
     <>
@@ -80,7 +55,7 @@ const ConLists = () => {
             <ConcertCard
               info={info}
               key={index}
-              like={true}
+              like={favorites && favorites.includes(info.id + "")}
               setLike={setFavorites}
             />
           ))}

--- a/src/components/concert/ConLists.jsx
+++ b/src/components/concert/ConLists.jsx
@@ -28,7 +28,7 @@ const ConLists = () => {
         let url = `/performance?`;
         url += keyword ? `keyword=${keyword}&` : "";
         url += category ? `genre=${category}&` : "";
-        url += `_page=${pages}&_limit=${PAGE.limit}`;
+        url += `page=${pages - 1}&limit=${PAGE.limit}`;
         await setLists(url, setInfos, totalCount, setTotalCount);
       } catch (error) {
         console.error(error, "에러");

--- a/src/components/concert/ConLists.jsx
+++ b/src/components/concert/ConLists.jsx
@@ -4,7 +4,6 @@ import ConcertCard from "./ConcertCard";
 import Navigation from "../common/Navigation";
 import Paging from "../common/Paging";
 import PAGE from "../../assets/constants/page";
-import instance from "../../assets/constants/instance";
 import setLists from "../../assets/tools/setLists";
 
 const ConLists = () => {
@@ -18,8 +17,8 @@ const ConLists = () => {
     .get("category")
     ?.replace(/[a-z]/g, (x) => x.toUpperCase());
   let keyword = urlSearch.get("keyword");
-  const [favoritePerformances, setFavoritePerformances] = useState(
-    JSON.parse(localStorage.getItem("favorites")) || {}
+  const [favorites, setFavorites] = useState(
+    JSON.parse(localStorage.getItem("favorites"))
   );
 
   useEffect(() => {
@@ -36,30 +35,32 @@ const ConLists = () => {
     };
     getInfos();
     setCurrentPage(pages);
+
+    //바뀐 정보로 카드를 그려요
+    infos.map((info, index) => {
+      let like = false;
+      if (favorites && favorites.includes(info.id + "")) {
+        like = true;
+      }
+      concertCards.push(
+        <ConcertCard
+          info={info}
+          key={index}
+          like={like}
+          setLike={setFavorites}
+        />
+      );
+    });
+    if (!infos.length) {
+      concertCards.push(
+        <div key="1">
+          <h2 className="notice">결과가 없습니다</h2>
+        </div>
+      );
+    }
   }, [url]);
 
   const concertCards = [];
-  infos.map((info, index) => {
-    let like = false;
-    if (favoritePerformances?.includes(info.id)) {
-      like = true;
-    }
-    concertCards.push(
-      <ConcertCard
-        info={info}
-        key={index}
-        like={like}
-        setLike={setFavoritePerformances}
-      />
-    );
-  });
-  if (!infos.length) {
-    concertCards.push(
-      <div key="1">
-        <h2 className="notice">결과가 없습니다</h2>
-      </div>
-    );
-  }
 
   return (
     <>
@@ -74,7 +75,16 @@ const ConLists = () => {
           </>
         )}
 
-        <div className="concert-list">{concertCards}</div>
+        <div className="concert-list">
+          {infos.map((info, index) => (
+            <ConcertCard
+              info={info}
+              key={index}
+              like={true}
+              setLike={setFavorites}
+            />
+          ))}
+        </div>
         <Paging totalCount={totalCount} currentPage={currentPage} />
       </div>
     </>

--- a/src/components/concert/ConcertCard.jsx
+++ b/src/components/concert/ConcertCard.jsx
@@ -27,8 +27,10 @@ const ConcertCard = (props) => {
         await instance.post(`/performance/${info.id}/like`);
         newFavorites = [...savedFavorites, info.id];
       }
+      if (setFavorites) {
+        setFavorites(newFavorites);
+      }
       setLikethis(!likethis);
-      setFavorites(newFavorites);
       localStorage.setItem("favorites", JSON.stringify(newFavorites));
     } catch (error) {
       console.error(error, "에러");

--- a/src/components/concert/ConcertCard.jsx
+++ b/src/components/concert/ConcertCard.jsx
@@ -1,14 +1,21 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import instance from "../../assets/constants/instance";
 
 const ConcertCard = (props) => {
-  const [likethis, setLikethis] = useState(props.like);
+  const url = useLocation();
+  const [likethis, setLikethis] = useState(false);
   const setFavorites = props.setLike;
   const navigate = useNavigate();
   const info = props.info;
   const className =
     info.status === "END" ? "hot" : info.status === "" ? "hidden" : "";
+
+  useEffect(() => {
+    if (props.like) {
+      setLikethis(true);
+    } else setLikethis(false);
+  });
 
   const likeChange = async (e) => {
     e.stopPropagation();

--- a/src/components/concert/MainPage.jsx
+++ b/src/components/concert/MainPage.jsx
@@ -5,6 +5,9 @@ import AdCarousel from "./AdCarousel";
 import ConcertCard from "./ConcertCard";
 
 const MainPage = () => {
+  const [favorites, setFavorites] = useState(
+    JSON.parse(localStorage.getItem("favorites"))
+  );
   const [concert, setConcert] = useState([]);
   const [musical, setMusical] = useState([]);
   const [play, setPlay] = useState([]);
@@ -37,13 +40,25 @@ const MainPage = () => {
   const musicalArr = [];
   const playArr = [];
   concert.map((info, index) => {
-    concertArr.push(<ConcertCard info={info} key={index} />);
+    let like = false;
+    if (favorites && favorites.includes(info.id + "")) {
+      like = true;
+    }
+    concertArr.push(<ConcertCard info={info} key={index} like={like} />);
   });
   musical.map((info, index) => {
-    musicalArr.push(<ConcertCard info={info} key={index} />);
+    let like = false;
+    if (favorites && favorites.includes(info.id + "")) {
+      like = true;
+    }
+    musicalArr.push(<ConcertCard info={info} key={index} like={like} />);
   });
   play.map((info, index) => {
-    playArr.push(<ConcertCard info={info} key={index} />);
+    let like = false;
+    if (favorites && favorites.includes(info.id + "")) {
+      like = true;
+    }
+    playArr.push(<ConcertCard info={info} key={index} like={like} />);
   });
 
   return (

--- a/src/components/mypage/MyConcert.jsx
+++ b/src/components/mypage/MyConcert.jsx
@@ -31,7 +31,7 @@ const MyConcert = () => {
 
   const concertCards = [];
   infos.map((info, index) => {
-    concertCards.push(<ConcertCard info={info} key={index} />);
+    concertCards.push(<ConcertCard info={info} key={index} like={true} />);
   });
   if (!infos.length) {
     concertCards.push(

--- a/src/components/mypage/MyConcert.jsx
+++ b/src/components/mypage/MyConcert.jsx
@@ -17,7 +17,9 @@ const MyConcert = () => {
   useEffect(() => {
     const getInfos = async () => {
       try {
-        const url = `/performance/favorite?_page=${pages}&_limit=${PAGE.limit}`;
+        const url = `/performance/favorite?page=${pages - 1}&limit=${
+          PAGE.limit
+        }`;
         await setLists(url, setInfos, totalCount, setTotalCount);
       } catch (error) {
         console.error(error, "에러");

--- a/test/db.json
+++ b/test/db.json
@@ -114,6 +114,26 @@
     },
     {
       "id": 31
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "VISIBLE",
+      "id": 32
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "HIDDEN",
+      "id": 33
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "VISIBLE",
+      "id": 34
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "HIDDEN",
+      "id": 35
     }
   ],
   "conInfo": [

--- a/test/db.json
+++ b/test/db.json
@@ -1,72 +1,119 @@
 {
-  "notifications": [
+  "notification": [
     {
       "id": 1,
-      "watching": "true"
+      "chatRoomId": 3,
+      "visibleType": "VISIBLE"
     },
     {
-      "watching": "visible",
+      "chatRoomId": "1",
+      "visibleType": "VISIBLE",
       "id": 2
     },
     {
-      "watching": "hidden",
+      "chatRoomId": "1",
+      "visibleType": "HIDDEN",
       "id": 3
     },
     {
-      "watching": "visible",
+      "chatRoomId": "1",
+      "visibleType": "VISIBLE",
       "id": 4
     },
     {
-      "watching": "hidden",
+      "chatRoomId": "1",
+      "visibleType": "HIDDEN",
       "id": 5
     },
     {
-      "watching": "visible",
       "id": 6
     },
     {
-      "watching": "visible",
       "id": 7
     },
     {
-      "watching": "visible",
       "id": 8
     },
     {
-      "watching": "hidden",
       "id": 9
     },
     {
-      "watching": "visible",
       "id": 10
     },
     {
-      "watching": "hidden",
       "id": 11
     },
     {
-      "watching": "visible",
       "id": 12
     },
     {
-      "watching": "hidden",
       "id": 13
     },
     {
-      "watching": "visible",
       "id": 14
     },
     {
-      "watching": "hidden",
       "id": 15
     },
     {
-      "watching": "visible",
       "id": 16
     },
     {
-      "watching": "hidden",
       "id": 17
+    },
+    {
+      "id": 18
+    },
+    {
+      "id": 19
+    },
+    {
+      "id": 20
+    },
+    {
+      "id": 21
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "VISIBLE",
+      "id": 22
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "HIDDEN",
+      "id": 23
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "VISIBLE",
+      "id": 24
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "HIDDEN",
+      "id": 25
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "VISIBLE",
+      "id": 26
+    },
+    {
+      "chatRoomId": "1",
+      "visibleType": "HIDDEN",
+      "id": 27
+    },
+    {
+      "id": 28
+    },
+    {
+      "id": 29
+    },
+    {
+      "id": 30
+    },
+    {
+      "id": 31
     }
   ],
   "conInfo": [
@@ -507,6 +554,12 @@
       "message": "40",
       "sendAt": 1708615485081,
       "id": 41
+    },
+    {
+      "memberId": "me",
+      "message": "아니 왜죠",
+      "sendAt": 1708617849152,
+      "id": 42
     }
   ],
   "performance-best": [

--- a/test/db.json
+++ b/test/db.json
@@ -128,7 +128,9 @@
       "performanceId": "1",
       "createDate": "202402020923",
       "roomName": "test2",
-      "tags": ["##"],
+      "tags": [
+        "##"
+      ],
       "id": 2
     },
     {
@@ -142,49 +144,67 @@
       "performanceId": "1",
       "createDate": "202402020930",
       "roomName": "test4",
-      "tags": ["adf", "adsfa", "adsfdsf"],
+      "tags": [
+        "adf",
+        "adsfa",
+        "adsfdsf"
+      ],
       "id": 5
     },
     {
       "performanceId": "1",
       "createDate": "202402020942",
       "roomName": "test5",
-      "tags": ["오당"],
+      "tags": [
+        "오당"
+      ],
       "id": 6
     },
     {
       "performanceId": "1",
       "createDate": "202402020943",
       "roomName": "test6",
-      "tags": ["6", "이당"],
+      "tags": [
+        "6",
+        "이당"
+      ],
       "id": 7
     },
     {
       "performanceId": "1",
       "createDate": "202402020943",
       "roomName": "test7",
-      "tags": ["7d이당"],
+      "tags": [
+        "7d이당"
+      ],
       "id": 8
     },
     {
       "performanceId": "1",
       "createDate": "202402020944",
       "roomName": "test8",
-      "tags": ["8"],
+      "tags": [
+        "8"
+      ],
       "id": 9
     },
     {
       "performanceId": "1",
       "createDate": "202402020945",
       "roomName": "test9",
-      "tags": ["9"],
+      "tags": [
+        "9"
+      ],
       "id": 10
     },
     {
       "performanceId": "1",
       "createDate": "202402021118",
       "roomName": "test10",
-      "tags": ["이당", "할증"],
+      "tags": [
+        "이당",
+        "할증"
+      ],
       "id": 11
     },
     {
@@ -243,856 +263,250 @@
   ],
   "chatMessages": [
     {
-      "id": 1,
-      "from": "me",
-      "text": "sendMessage",
-      "timeStamp": 12345
+      "memberId": "me",
+      "message": "감자감자",
+      "sendAt": 1708599166315,
+      "id": 1
     },
     {
-      "from": "me",
-      "text": "어허",
-      "timeStamp": 1707832864081,
+      "memberId": "me",
+      "message": "1",
+      "sendAt": 1708615382767,
       "id": 2
     },
     {
-      "from": "me",
-      "text": "지금쯤 세팅이 되었나요?",
-      "timeStamp": 1707832875343,
+      "memberId": "me",
+      "message": "2",
+      "sendAt": 1708615385680,
       "id": 3
     },
     {
-      "from": "other",
-      "text": "지금부터 메세지를 열 개 보냅니다.",
-      "timeStamp": 1707836027634,
+      "memberId": "me",
+      "message": "3",
+      "sendAt": 1708615386662,
       "id": 4
     },
     {
-      "from": "other",
-      "text": "하나",
-      "timeStamp": 1707836029872,
+      "memberId": "me",
+      "message": "4",
+      "sendAt": 1708615387537,
       "id": 5
     },
     {
-      "from": "other",
-      "text": "둘",
-      "timeStamp": 1707836031671,
+      "memberId": "other",
+      "message": "5",
+      "sendAt": 1708615390125,
       "id": 6
     },
     {
-      "from": "other",
-      "text": "셋",
-      "timeStamp": 1707836033522,
+      "memberId": "other",
+      "message": "6",
+      "sendAt": 1708615391381,
       "id": 7
     },
     {
-      "from": "other",
-      "text": "넷",
-      "timeStamp": 1707836037633,
+      "memberId": "other",
+      "message": "7",
+      "sendAt": 1708615393566,
       "id": 8
     },
     {
-      "from": "other",
-      "text": "다섯",
-      "timeStamp": 1707836040696,
+      "memberId": "me",
+      "message": "8",
+      "sendAt": 1708615395932,
       "id": 9
     },
     {
-      "from": "me",
-      "text": "여섯",
-      "timeStamp": 1707836043959,
+      "memberId": "other",
+      "message": "9",
+      "sendAt": 1708615400388,
       "id": 10
     },
     {
-      "from": "me",
-      "text": "일곱",
-      "timeStamp": 1707836051471,
+      "memberId": "other",
+      "message": "10",
+      "sendAt": 1708615413089,
       "id": 11
     },
     {
-      "from": "me",
-      "text": "여덟",
-      "timeStamp": 1707836054984,
+      "memberId": "other",
+      "message": "11",
+      "sendAt": 1708615415865,
       "id": 12
     },
     {
-      "from": "other",
-      "text": "아홉",
-      "timeStamp": 1707836060084,
+      "memberId": "other",
+      "message": "112",
+      "sendAt": 1708615417041,
       "id": 13
     },
     {
-      "from": "other",
-      "text": "열",
-      "timeStamp": 1707836062309,
+      "memberId": "other",
+      "message": "13",
+      "sendAt": 1708615419174,
       "id": 14
     },
     {
-      "from": "me",
-      "text": "옵저버를 테스트하려면 메세지가 서른 개는 필요하겠군",
-      "timeStamp": 1707837412843,
+      "memberId": "other",
+      "message": "14",
+      "sendAt": 1708615420366,
       "id": 15
     },
     {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837415877,
+      "memberId": "other",
+      "message": "15",
+      "sendAt": 1708615421820,
       "id": 16
     },
     {
-      "from": "me",
-      "text": "아 메세지 쌓아놓은 거 왜 날렸지 ㅋㅋㅋ",
-      "timeStamp": 1707837423329,
+      "memberId": "other",
+      "message": "16",
+      "sendAt": 1708615422898,
       "id": 17
     },
     {
-      "from": "other",
-      "text": "눈물이 나죠\n",
-      "timeStamp": 1707837429170,
+      "memberId": "other",
+      "message": "17",
+      "sendAt": 1708615424658,
       "id": 18
     },
     {
-      "from": "other",
-      "text": "눈물이 차올라서 고갤 들어",
-      "timeStamp": 1707837439943,
+      "memberId": "me",
+      "message": "18",
+      "sendAt": 1708615427229,
       "id": 19
     },
     {
-      "from": "other",
-      "text": "흐르지 못하게 또 살짝 웃어",
-      "timeStamp": 1707837447358,
+      "memberId": "me",
+      "message": "19",
+      "sendAt": 1708615429432,
       "id": 20
     },
     {
-      "from": "me",
-      "text": "내가 왜 이러는지",
-      "timeStamp": 1707837453131,
+      "memberId": "me",
+      "message": "20",
+      "sendAt": 1708615431294,
       "id": 21
     },
     {
-      "from": "me",
-      "text": "부끄럼도 없는지",
-      "timeStamp": 1707837457384,
+      "memberId": "me",
+      "message": "21",
+      "sendAt": 1708615437381,
       "id": 22
     },
     {
-      "from": "other",
-      "text": "자존심은 곱게 접어 하늘위로",
-      "timeStamp": 1707837466293,
+      "memberId": "me",
+      "message": "22",
+      "sendAt": 1708615439881,
       "id": 23
     },
     {
-      "from": "other",
-      "text": "오~",
-      "timeStamp": 1707837470167,
+      "memberId": "me",
+      "message": "23",
+      "sendAt": 1708615442118,
       "id": 24
     },
     {
-      "from": "me",
-      "text": "한번도 못 했던 마알",
-      "timeStamp": 1707837478705,
+      "memberId": "me",
+      "message": "24",
+      "sendAt": 1708615445093,
       "id": 25
     },
     {
-      "from": "me",
-      "text": "울면서 할 줄은 나 몰랐던 마알",
-      "timeStamp": 1707837487393,
+      "memberId": "me",
+      "message": "25",
+      "sendAt": 1708615449357,
       "id": 26
     },
     {
-      "from": "other",
-      "text": "나는요",
-      "timeStamp": 1707837491993,
+      "memberId": "me",
+      "message": "26",
+      "sendAt": 1708615452836,
       "id": 27
     },
     {
-      "from": "me",
-      "text": "오빠가",
-      "timeStamp": 1707837495993,
+      "memberId": "me",
+      "message": "27",
+      "sendAt": 1708615455684,
       "id": 28
     },
     {
-      "from": "other",
-      "text": "좋은거얼~~~",
-      "timeStamp": 1707837502580,
+      "memberId": "me",
+      "message": "28",
+      "sendAt": 1708615457383,
       "id": 29
     },
     {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ나 칠걸",
-      "timeStamp": 1707837510954,
+      "memberId": "other",
+      "message": "29",
+      "sendAt": 1708615460152,
       "id": 30
     },
     {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707837513570,
+      "memberId": "other",
+      "message": "30",
+      "sendAt": 1708615461920,
       "id": 31
     },
     {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837514828,
+      "memberId": "other",
+      "message": "31",
+      "sendAt": 1708615463472,
       "id": 32
     },
     {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837516290,
+      "memberId": "me",
+      "message": "32",
+      "sendAt": 1708615465964,
       "id": 33
     },
     {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837518627,
+      "memberId": "me",
+      "message": "33",
+      "sendAt": 1708615467778,
       "id": 34
     },
     {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707837519698,
+      "memberId": "other",
+      "message": "34",
+      "sendAt": 1708615470572,
       "id": 35
     },
     {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837521391,
+      "memberId": "other",
+      "message": "35",
+      "sendAt": 1708615472060,
       "id": 36
     },
     {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707837523442,
+      "memberId": "other",
+      "message": "36",
+      "sendAt": 1708615473798,
       "id": 37
     },
     {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837524754,
+      "memberId": "other",
+      "message": "377",
+      "sendAt": 1708615476257,
       "id": 38
     },
     {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837528507,
+      "memberId": "other",
+      "message": "288",
+      "sendAt": 1708615479991,
       "id": 39
     },
     {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837532394,
+      "memberId": "me",
+      "message": "39",
+      "sendAt": 1708615483555,
       "id": 40
     },
     {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837534194,
+      "memberId": "me",
+      "message": "40",
+      "sendAt": 1708615485081,
       "id": 41
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837536229,
-      "id": 42
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ?",
-      "timeStamp": 1707837539684,
-      "id": 43
-    },
-    {
-      "from": "other",
-      "text": "ㅇㄷㅁㄴㅇㄹ ",
-      "timeStamp": 1707837543655,
-      "id": 44
-    },
-    {
-      "from": "me",
-      "text": "ㅋㅋㅋㅋㅋㅋㅋ",
-      "timeStamp": 1707837548316,
-      "id": 45
-    },
-    {
-      "from": "other",
-      "text": "ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ",
-      "timeStamp": 1707837551959,
-      "id": 46
-    },
-    {
-      "from": "other",
-      "text": "ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ",
-      "timeStamp": 1707837554616,
-      "id": 47
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837557306,
-      "id": 48
-    },
-    {
-      "from": "me",
-      "text": "아 스크롤 이벤트 세팅해야지..",
-      "timeStamp": 1707837570479,
-      "id": 49
-    },
-    {
-      "from": "me",
-      "text": "돌아라 스크롤 이벤트!",
-      "timeStamp": 1707837748945,
-      "id": 50
-    },
-    {
-      "from": "me",
-      "text": "리셋. 돌아라 스크롤 이벤트!",
-      "timeStamp": 1707837761669,
-      "id": 51
-    },
-    {
-      "from": "me",
-      "text": "흠 잘 도는군",
-      "timeStamp": 1707837770498,
-      "id": 52
-    },
-    {
-      "from": "other",
-      "text": "bottom으로 스크롤이 돌 것인가?",
-      "timeStamp": 1707837867934,
-      "id": 53
-    },
-    {
-      "from": "other",
-      "text": "와아 안돈다\n",
-      "timeStamp": 1707837872808,
-      "id": 54
-    },
-    {
-      "from": "me",
-      "text": "top은?",
-      "timeStamp": 1707837891384,
-      "id": 55
-    },
-    {
-      "from": "me",
-      "text": "와아 안돈다",
-      "timeStamp": 1707837895019,
-      "id": 56
-    },
-    {
-      "from": "me",
-      "text": "숫자 던졌어요? 이거 먹히나 봅시다",
-      "timeStamp": 1707837933260,
-      "id": 57
-    },
-    {
-      "from": "me",
-      "text": "부족하나?",
-      "timeStamp": 1707837944334,
-      "id": 58
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707837948375,
-      "id": 59
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837950071,
-      "id": 60
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837952216,
-      "id": 61
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707837954301,
-      "id": 62
-    },
-    {
-      "from": "me",
-      "text": "아 좀 짧네요?",
-      "timeStamp": 1707837962032,
-      "id": 63
-    },
-    {
-      "from": "me",
-      "text": "되나 봅시다",
-      "timeStamp": 1707838035844,
-      "id": 64
-    },
-    {
-      "from": "other",
-      "text": "아아 부족하죠?",
-      "timeStamp": 1707838042119,
-      "id": 65
-    },
-    {
-      "from": "other",
-      "text": "뭐가 문제인지 알 수가 없죠",
-      "timeStamp": 1707838047993,
-      "id": 66
-    },
-    {
-      "from": "me",
-      "text": "돌겠죠",
-      "timeStamp": 1707838052882,
-      "id": 67
-    },
-    {
-      "from": "me",
-      "text": "되랏!",
-      "timeStamp": 1707838163507,
-      "id": 68
-    },
-    {
-      "from": "other",
-      "text": "아아 돌겠죠",
-      "timeStamp": 1707838168757,
-      "id": 69
-    },
-    {
-      "from": "other",
-      "text": "안되죠",
-      "timeStamp": 1707838171433,
-      "id": 70
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707838243231,
-      "id": 71
-    },
-    {
-      "from": "other",
-      "text": "망ㅋ",
-      "timeStamp": 1707838247083,
-      "id": 72
-    },
-    {
-      "from": "me",
-      "text": "이럼 되나?",
-      "timeStamp": 1707838287606,
-      "id": 73
-    },
-    {
-      "from": "me",
-      "text": "야",
-      "timeStamp": 1707838290256,
-      "id": 74
-    },
-    {
-      "from": "other",
-      "text": "유멬미크레이지",
-      "timeStamp": 1707838298143,
-      "id": 75
-    },
-    {
-      "from": "me",
-      "text": "아 스크롤 이상한 데 멈추죠",
-      "timeStamp": 1707838391184,
-      "id": 76
-    },
-    {
-      "from": "me",
-      "text": "아 걸리지 말라고",
-      "timeStamp": 1707838396582,
-      "id": 77
-    },
-    {
-      "from": "other",
-      "text": "한 칸 더 돌라고!!!",
-      "timeStamp": 1707838404282,
-      "id": 78
-    },
-    {
-      "from": "other",
-      "text": "이야 스크롤씨 덕분에 채팅 70개 쌓였죠? 말 나온 김에 옵저버나 돌려봅시다..",
-      "timeStamp": 1707838497821,
-      "id": 79
-    },
-    {
-      "from": "other",
-      "text": "마리아란마리아",
-      "timeStamp": 1707838525484,
-      "id": 80
-    },
-    {
-      "from": "me",
-      "text": "아아아 와따시노 코오이와~~~",
-      "timeStamp": 1707838571953,
-      "id": 81
-    },
-    {
-      "from": "me",
-      "text": "채팅을 새로 쳐요",
-      "timeStamp": 1707838586310,
-      "id": 82
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707838593886,
-      "id": 83
-    },
-    {
-      "from": "other",
-      "text": "호옥시?",
-      "timeStamp": 1707839251009,
-      "id": 84
-    },
-    {
-      "from": "other",
-      "text": "헐 역시",
-      "timeStamp": 1707839256221,
-      "id": 85
-    },
-    {
-      "from": "me",
-      "text": "이야,,, 돈다 디비진다",
-      "timeStamp": 1707839267501,
-      "id": 86
-    },
-    {
-      "from": "me",
-      "text": "채팅",
-      "timeStamp": 1707839338837,
-      "id": 87
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707839345112,
-      "id": 88
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹㅁㄴㅇㄹ",
-      "timeStamp": 1707839383568,
-      "id": 89
-    },
-    {
-      "from": "me",
-      "text": "아니 진짜 잠깜나",
-      "timeStamp": 1707840604127,
-      "id": 90
-    },
-    {
-      "from": "me",
-      "text": "아니",
-      "timeStamp": 1707840805317,
-      "id": 91
-    },
-    {
-      "from": "me",
-      "text": "?",
-      "timeStamp": 1707841099445,
-      "id": 92
-    },
-    {
-      "from": "me",
-      "text": "채팅",
-      "timeStamp": 1707887168734,
-      "id": 93
-    },
-    {
-      "from": "me",
-      "text": "새 채팅",
-      "timeStamp": 1707887202558,
-      "id": 94
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707887212744,
-      "id": 95
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707887222050,
-      "id": 96
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707887237780,
-      "id": 97
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄻㄴㅇㄻㄴㅇㄹ",
-      "timeStamp": 1707887242814,
-      "id": 98
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707887265836,
-      "id": 99
-    },
-    {
-      "from": "other",
-      "text": "새 메세지",
-      "timeStamp": 1707887277045,
-      "id": 100
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707888381240,
-      "id": 101
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707888387514,
-      "id": 102
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707888434599,
-      "id": 103
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707888629155,
-      "id": 104
-    },
-    {
-      "from": "other",
-      "text": "ㅁㄴㅇㄹ",
-      "timeStamp": 1707888634578,
-      "id": 105
-    },
-    {
-      "from": "other",
-      "text": "실화냐",
-      "timeStamp": 1707888641765,
-      "id": 106
-    },
-    {
-      "from": "me",
-      "text": "ㅁㄴㅇㄻㄴㅇㄻㄴㅇㄻㄴㅇㄹ",
-      "timeStamp": 1707888683430,
-      "id": 107
-    },
-    {
-      "from": "other",
-      "text": "slrk dho qkRNlwy?",
-      "timeStamp": 1707888697090,
-      "id": 108
-    },
-    {
-      "from": "me",
-      "text": "push 한 메세지",
-      "timeStamp": 1707889165651,
-      "id": 109
-    },
-    {
-      "from": "me",
-      "text": "hey",
-      "timeStamp": 1707889278499,
-      "id": 110
-    },
-    {
-      "from": "me",
-      "text": "asdf",
-      "timeStamp": 1707889599038,
-      "id": 111
-    },
-    {
-      "from": "me",
-      "text": "qhqtlek",
-      "timeStamp": 1707889666512,
-      "id": 112
-    },
-    {
-      "from": "me",
-      "text": "너어는 왜 변하니?",
-      "timeStamp": 1707889676126,
-      "id": 113
-    },
-    {
-      "from": "me",
-      "text": "야 뭐가 문제야?",
-      "timeStamp": 1707889687973,
-      "id": 114
-    },
-    {
-      "from": "me",
-      "text": "장난하니~~",
-      "timeStamp": 1707889696450,
-      "id": 115
-    },
-    {
-      "from": "me",
-      "text": "두근",
-      "timeStamp": 1707921201002,
-      "id": 116
-    },
-    {
-      "from": "me",
-      "text": "야",
-      "timeStamp": 1707921205965,
-      "id": 117
-    },
-    {
-      "from": "me",
-      "text": "이러기임?",
-      "timeStamp": 1707921209551,
-      "id": 118
-    },
-    {
-      "from": "me",
-      "text": "헤이",
-      "timeStamp": 1707921226314,
-      "id": 119
-    },
-    {
-      "from": "me",
-      "text": "야아아",
-      "timeStamp": 1707921229601,
-      "id": 120
-    },
-    {
-      "from": "other",
-      "text": "모가문제죠",
-      "timeStamp": 1707921234415,
-      "id": 121
-    },
-    {
-      "from": "other",
-      "text": "되어랏",
-      "timeStamp": 1707921323696,
-      "id": 122
-    },
-    {
-      "from": "other",
-      "text": "왜 안되죠",
-      "timeStamp": 1707921340872,
-      "id": 123
-    },
-    {
-      "from": "me",
-      "text": "di",
-      "timeStamp": 1707921559984,
-      "id": 124
-    },
-    {
-      "from": "me",
-      "text": "이건 되나 보자",
-      "timeStamp": 1707921647126,
-      "id": 125
-    },
-    {
-      "from": "me",
-      "text": "얘도 안 되네",
-      "timeStamp": 1707921656625,
-      "id": 126
-    },
-    {
-      "from": "other",
-      "text": "아마 이젠 될 것",
-      "timeStamp": 1707921845709,
-      "id": 127
-    },
-    {
-      "from": "other",
-      "text": "그라췌",
-      "timeStamp": 1707921850922,
-      "id": 128
-    },
-    {
-      "from": "me",
-      "text": "근데?",
-      "timeStamp": 1707921933349,
-      "id": 129
-    },
-    {
-      "from": "other",
-      "text": "아맞다",
-      "timeStamp": 1707922482383,
-      "id": 130
-    },
-    {
-      "from": "other",
-      "text": "지금은",
-      "timeStamp": 1707922484432,
-      "id": 131
-    },
-    {
-      "from": "other",
-      "text": "여기만",
-      "timeStamp": 1707922486744,
-      "id": 132
-    },
-    {
-      "from": "other",
-      "text": "모야 안되잖아",
-      "timeStamp": 1707922492894,
-      "id": 133
-    },
-    {
-      "from": "other",
-      "text": "이젠",
-      "timeStamp": 1707922530698,
-      "id": 134
-    },
-    {
-      "from": "other",
-      "text": "되나",
-      "timeStamp": 1707922533873,
-      "id": 135
-    },
-    {
-      "from": "other",
-      "text": "되는군",
-      "timeStamp": 1707922537360,
-      "id": 136
-    },
-    {
-      "from": "me",
-      "text": "입력이 되나 보아요",
-      "timeStamp": 1707923717669,
-      "id": 137
-    },
-    {
-      "from": "me",
-      "text": "되나",
-      "timeStamp": 1707923722194,
-      "id": 138
-    },
-    {
-      "from": "other",
-      "text": "되나",
-      "timeStamp": 1707923726256,
-      "id": 139
-    },
-    {
-      "from": "other",
-      "text": "이것도 되나",
-      "timeStamp": 1707923729406,
-      "id": 140
-    },
-    {
-      "from": "other",
-      "text": "되는군",
-      "timeStamp": 1707923734519,
-      "id": 141
-    },
-    {
-      "from": "me",
-      "text": "맨 밑으로 가라!",
-      "timeStamp": 1707925201341,
-      "id": 142
     }
   ],
   "performance-best": [


### PR DESCRIPTION
1. 쿼리스트링 수정 후 공연 목록이 제대로 받아집니다.
2. 공연 리스트가 뜨는 모든 페이지에서 찜 표기 및 취소가 가능합니다.
3. refresh token 만료 시 공연 리스트가 안 뜨는 문제를 해결했습니다.
4. notification을 fetch가 아니라 navigator.sendBeacon으로 바꾸었습니다.
5. 채팅 메세지 함수 일부를 클래스로 분리했습니다.

찜한 공연 표기가 제대로 되지 않는 문제가 있습니다. 계속 수정중입니다. 괜찮으시다면 머지는 좀 미뤄주셨으면 좋겠어요.