### PR TITLE
채팅방 생성 및 생성 시 notification 리팩토링

### DIFF
--- a/src/assets/tools/setLists.jsx
+++ b/src/assets/tools/setLists.jsx
@@ -2,7 +2,7 @@ import instance from "../constants/instance";
 
 const setLists = async (request, setInfos, totalCount, setTotalCount) => {
   const response = await instance.get(request);
-  console.log(response);
+  console.log(response, "setLists");
   const datas = await response.data;
   setInfos(datas.content);
   const length = datas.totalElements;

--- a/src/components/chat/Chat.jsx
+++ b/src/components/chat/Chat.jsx
@@ -11,16 +11,16 @@ import {
   ChatMessageBundle,
 } from "../../assets/tools/chatFunctions";
 
+//json-server용 instance
+//const instance = axios.create({ baseURL: "http://localhost:3000" });
 //컴포넌트 리렌더링을 막기 위한 조치
 const basic = {
-  chatRoomId: 12,
-  roomName: "토요일 콘서트 같이 가자요... 제발요",
-  performanceName: "리렌더링용 공연이름",
+  chatRoomId: 0,
+  roomName: "채팅방",
+  performanceName: "공연",
   userCount: "1",
   members: [],
 };
-
-//const instance = axios.create({ baseURL: "http://localhost:3000" });
 
 const Chat = () => {
   const myId = useRecoilValue(myInfoState).username;
@@ -34,7 +34,6 @@ const Chat = () => {
   const observerRef = useRef(null);
   const messageRef = useRef(null);
   const scrollRef = useRef(null);
-  const enterRef = useRef(null);
   const textRef = useRef(null);
   const chatMembersRef = useRef([]);
   const firstMessageRef = useRef(null);
@@ -49,15 +48,6 @@ const Chat = () => {
     setPrevMessage,
     chatRoomId
   );
-
-  //현재 채팅을 보낼 수 있는 상태인지 확인합니다.
-  const checkSendable = () => {
-    if (textRef.current.value && !sendButton) {
-      setSendButton(true);
-    } else if (!textRef.current.value && sendButton) {
-      setSendButton(false);
-    }
-  };
 
   const toggleOpen = (e) => {
     e.stopPropagation();
@@ -122,6 +112,16 @@ const Chat = () => {
     if (talker === "me") setTalker("other");
     else setTalker("me");
   };
+
+  //현재 채팅을 보낼 수 있는 상태인지 확인합니다.
+  const checkSendable = () => {
+    if (textRef.current.value && !sendButton) {
+      setSendButton(true);
+    } else if (!textRef.current.value && sendButton) {
+      setSendButton(false);
+    }
+  };
+
   const sendMessage = async () => {
     const info = textRef.current.value;
     textRef.current.value = "";
@@ -132,6 +132,9 @@ const Chat = () => {
       message: info,
     };
     const response = await instance.post("/chatMessages", newMessage);
+    //(끝) 웹소켓으로 연결될 경우 여기까지가 post임.
+
+    //웹소켓으로 만들 경우 무조건 array화 시켜서 AddMessages로 받아올 것입니다.
     const datas = await response.data;
     lastMessageRef.current = datas.id;
     setPrevMessage(datas);
@@ -186,11 +189,12 @@ const Chat = () => {
             </div>
           )}
           <div className="messages" ref={messageRef}>
-            <div className="system-message" ref={enterRef}>
+            <hr aria-label="여기까지 읽었어요" />
+            {/**<div className="system-message">
               <div className="profile-img"></div>
               <div className="text">입장하였습니다.</div>
               <div className="message-time">nan:nan:nan</div>
-            </div>
+            </div>*/}
           </div>
         </div>
         <div className="send-area">

--- a/src/components/chat/ChatList.jsx
+++ b/src/components/chat/ChatList.jsx
@@ -5,7 +5,6 @@ import CreateChatRoom from "./CreateChatRoom";
 import Paging from "../common/Paging";
 import instance from "../../assets/constants/instance";
 import setLists from "../../assets/tools/setLists";
-import PAGE from "../../assets/constants/page";
 
 const ChatList = () => {
   const [tagInfo, setTagInfo] = useState([]);
@@ -49,7 +48,7 @@ const ChatList = () => {
       try {
         let url = "/chatRoom/performance/";
         url += concertTitle;
-        url += `?page=${pages - 1}&limit=${PAGE.limit}`;
+        url += `?page=${pages - 1}`; //limit=5
         await setLists(url, setData, totalCount, setTotalCount);
       } catch (error) {
         console.error("데이터오류", error);
@@ -124,7 +123,7 @@ const ChatList = () => {
           </div>
         )}
       </div>
-      <Paging totalCount={totalCount} currentPage={currentPage} />
+      <Paging totalCount={totalCount} currentPage={currentPage} limit={5} />
     </div>
   );
 };

--- a/src/components/chat/ChatList.jsx
+++ b/src/components/chat/ChatList.jsx
@@ -61,9 +61,7 @@ const ChatList = () => {
 
   const handleSearch = async () => {
     try {
-      const tag_id = 1;
-      //tag_id를 무엇으로 할 것인지 확인이 필요함.
-      let url = `/room/search/performance/${concertTitle}/tag/${tag_id}`;
+      let url = `/room/search/performance/${concertTitle}/tag/${searchHashtag}`;
       await setLists(url, setData, totalCount, setTotalCount);
     } catch (error) {
       console.error(error, "에러");

--- a/src/components/chat/ChatRoom.jsx
+++ b/src/components/chat/ChatRoom.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 const ChatRoom = ({ searchData }) => {
   const navigate = useNavigate();
   const { concertTitle } = useParams();
-  console.log(searchData);
   return (
     <div
       className="chat-room"

--- a/src/components/chat/ChatRoom.jsx
+++ b/src/components/chat/ChatRoom.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 const ChatRoom = ({ searchData }) => {
   const navigate = useNavigate();
   const { concertTitle } = useParams();
+  console.log(searchData);
   return (
     <div
       className="chat-room"

--- a/src/components/chat/ChatToggle.jsx
+++ b/src/components/chat/ChatToggle.jsx
@@ -36,6 +36,11 @@ const ChatToggle = (props) => {
         "/notification/chatRoom-event",
         data
       );
+      if (members.length === 1) {
+        const response3 = await instance.post(
+          `/notification/unsubscribe-channel?chatRoomId=${chatRoomId}`
+        );
+      }
       if (response.status === 204) {
         window.alert("채팅방에서 퇴장했습니다.");
         navigate(`/title/${concertTitle}/chat`);

--- a/src/components/chat/CreateChatRoom.jsx
+++ b/src/components/chat/CreateChatRoom.jsx
@@ -54,9 +54,9 @@ const CreateChatRoom = ({ onClose, performanceId }) => {
       }
       const num = Number(performanceId);
       const data = {
-        roomName,
-        num,
-        tagLists,
+        name: roomName,
+        performance_id: num,
+        tags: tagLists,
       };
       const response = await instance.post("/chatRoom", data);
       if (response.status === 201) {

--- a/src/components/chat/CreateChatRoom.jsx
+++ b/src/components/chat/CreateChatRoom.jsx
@@ -52,12 +52,13 @@ const CreateChatRoom = ({ onClose, performanceId }) => {
         setRoomMsg("채팅방 제목을 적어주세요");
         return;
       }
-      const num = Number(performanceId);
+      const performance_id = Number(performanceId);
       const data = {
-        name: roomName,
-        performance_id: num,
-        tags: tagLists,
+        roomName,
+        performance_id,
+        tagLists,
       };
+      console.log(data);
       const response = await instance.post("/chatRoom", data);
       if (response.status === 201) {
         const newChatroom = await response.data.id;

--- a/src/components/chat/CreateChatRoom.jsx
+++ b/src/components/chat/CreateChatRoom.jsx
@@ -52,11 +52,11 @@ const CreateChatRoom = ({ onClose, performanceId }) => {
         setRoomMsg("채팅방 제목을 적어주세요");
         return;
       }
-      const performance_id = Number(performanceId);
+      const idToNum = Number(performanceId);
       const data = {
-        roomName,
-        performance_id,
-        tagLists,
+        roomName: roomName,
+        performanceId: idToNum,
+        tags: tagLists,
       };
       console.log(data);
       const response = await instance.post("/chatRoom", data);

--- a/src/components/chat/CreateChatRoom.jsx
+++ b/src/components/chat/CreateChatRoom.jsx
@@ -52,10 +52,9 @@ const CreateChatRoom = ({ onClose, performanceId }) => {
         setRoomMsg("채팅방 제목을 적어주세요");
         return;
       }
-      const idToNum = Number(performanceId);
       const data = {
         roomName: roomName,
-        performanceId: idToNum,
+        performanceId: performanceId,
         tags: tagLists,
       };
       console.log(data);

--- a/src/components/chat/CreateChatRoom.jsx
+++ b/src/components/chat/CreateChatRoom.jsx
@@ -60,21 +60,16 @@ const CreateChatRoom = ({ onClose, performanceId }) => {
       console.log(data);
       const response = await instance.post("/chatRoom", data);
       if (response.status === 201) {
-        const newChatroom = await response.data.id;
-        const data2 = {
-          performanceId: performanceId,
-          chatRoomId: newChatroom,
-        };
+        const chatRoomId = await response.data.chatRoomId;
         const response2 = await instance.post(
-          "/notification/subscribe-channel",
-          data2
+          `/notification/subscribe-channel?chatRoomId=${chatRoomId}`
         );
         console.log("채팅방이 성공적으로 생성되었습니다.", response.data);
         setShowCompleteModal(true);
         setTimeout(() => {
           onClose();
           setShowCompleteModal(false);
-          navigate(`/title/${performanceId}/chat/${newChatroom}`);
+          navigate(`/title/${performanceId}/chat/${chatRoomId}`);
         }, 1500);
       }
     } catch (error) {

--- a/src/components/chat/MyChat.jsx
+++ b/src/components/chat/MyChat.jsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router-dom";
 import ChatRoom from "./ChatRoom";
 import Paging from "../common/Paging";
 import setLists from "../../assets/tools/setLists";
-import PAGE from "../../assets/constants/page";
 
 const MyChat = () => {
   const [datas, setData] = useState([]);
@@ -17,7 +16,7 @@ const MyChat = () => {
     const getData = async () => {
       try {
         let url = "/chatRoom/member";
-        url += `?page=${pages - 1}&limit=${PAGE.limit}`;
+        url += `?page=${pages - 1}`; //limit=5
         await setLists(url, setData, totalCount, setTotalCount);
       } catch (error) {
         console.error("데이터오류", error);
@@ -38,7 +37,7 @@ const MyChat = () => {
         user favorite으로 필터링한 결과물이 없어 임시로 3개만 끊어 그립니다.
       </p>
       <div className="list-container">{chatRooms}</div>
-      <Paging totalCount={totalCount} currentPage={currentPage} />
+      <Paging totalCount={totalCount} currentPage={currentPage} limit={5} />
     </div>
   );
 };

--- a/src/components/common/Paging.jsx
+++ b/src/components/common/Paging.jsx
@@ -13,7 +13,7 @@ import PAGE from "../../assets/constants/page";
  */
 
 const Paging = (props) => {
-  if (props.totalCount <= PAGE.limit) return;
+  if (props.totalCount <= props.limit) return;
   const navigate = useNavigate();
   const url = useLocation();
   const currentPageChange = (event) => {
@@ -33,7 +33,7 @@ const Paging = (props) => {
   const totalCount = props.totalCount;
   const pageCount = PAGE.pageCount;
   const currentPage = props.currentPage;
-  const limit = PAGE.limit;
+  const limit = props.limit;
   const totalPage = Math.ceil(totalCount / limit);
   const startPage = (Math.ceil(currentPage / pageCount) - 1) * pageCount + 1;
   const endPage = Math.ceil(currentPage / pageCount) * pageCount;

--- a/src/components/concert/ConLists.jsx
+++ b/src/components/concert/ConLists.jsx
@@ -60,7 +60,7 @@ const ConLists = () => {
             />
           ))}
         </div>
-        <Paging totalCount={totalCount} currentPage={currentPage} />
+        <Paging totalCount={totalCount} currentPage={currentPage} limit={10} />
       </div>
     </>
   );

--- a/src/components/mypage/MyConcert.jsx
+++ b/src/components/mypage/MyConcert.jsx
@@ -46,7 +46,7 @@ const MyConcert = () => {
       <div className="mypage-like-list">
         <div className="concert-list">{concertCards}</div>
       </div>
-      <Paging totalCount={totalCount} currentPage={currentPage} />
+      <Paging totalCount={totalCount} currentPage={currentPage} limit={10} />
     </div>
   );
 };


### PR DESCRIPTION
채팅방 생성 시, 채팅 쪽과 알람 쪽에 보내야 하는 데이터 형식을 조정했습니다.
채팅방 내부에서의 동작은 subscribe와 짝이 되는 unsubscribe를 제외하고 손대지 않았어요.
한 사람이 여러 채팅방에 들어갈 것을 대비해 마지막 메세지 아이디를 키-값 형식으로 저장하도록 세팅했습니다.
공연 리스트는 한 페이지 10개이고, 채팅 리스트는 한 페이지 5개라서 Paging 컴포넌트의 limit을 prop로 받아오도록 변경했습니다.